### PR TITLE
Handle missing filesystem in persistence operations

### DIFF
--- a/src/web/WebSettingsService.cpp
+++ b/src/web/WebSettingsService.cpp
@@ -448,7 +448,9 @@ void WebSettingsService::begin() {
 }
 
 void WebSettingsService::save() {
-    _fsPersistence.writeToFS();
+    if (!_fsPersistence.writeToFS()) {
+        emsesp::EMSESP::logger().err("Failed to save web settings: file system not available");
+    }
 }
 
 // build the json profile to send back


### PR DESCRIPTION
## Summary
- guard FS persistence reads and writes when filesystem is unavailable
- log failures and disable update handler on repeated write errors
- warn when web settings save fails

## Testing
- `make` *(fails: IPAddress.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9d57e6d083239fb3d5fb12c3b01c