### PR TITLE
Delay WebSettings persistence until filesystem ready

### DIFF
--- a/lib_standalone/FSPersistence.h
+++ b/lib_standalone/FSPersistence.h
@@ -44,6 +44,10 @@ class FSPersistence {
         }
     }
 
+    bool isEnabled() const {
+        return _updateHandlerId != 0;
+    }
+
   private:
     JsonStateReader<T>   _stateReader;
     JsonStateUpdater<T>  _stateUpdater;

--- a/src/ESP32React/FSPersistence.h
+++ b/src/ESP32React/FSPersistence.h
@@ -98,6 +98,10 @@ class FSPersistence {
         }
     }
 
+    bool isEnabled() const {
+        return _updateHandlerId != 0;
+    }
+
   private:
     JsonStateReader<T>   _stateReader;
     JsonStateUpdater<T>  _stateUpdater;

--- a/src/web/WebSettingsService.h
+++ b/src/web/WebSettingsService.h
@@ -135,6 +135,7 @@ class WebSettingsService : public StatefulService<WebSettings> {
 
     void begin();
     void save();
+    void enablePersistence();
 
   private:
     HttpEndpoint<WebSettings>  _httpEndpoint;


### PR DESCRIPTION
## Summary
- Disable WebSettings file persistence until the filesystem mounts
- Load settings and enable persistence after LittleFS starts, with safeguard checks
- Add helper to FSPersistence to check if persistence is active

## Testing
- `pio run -e native` *(fails: IPAddress.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9d58e8988323b1ea8c9c15168544