### PR TITLE
Fix EMSESP redefinition by separating logger stub

### DIFF
--- a/src/ESP32React/FSPersistence.h
+++ b/src/ESP32React/FSPersistence.h
@@ -5,12 +5,9 @@
 #include "FS.h"
 #include <uuid/log.h>
 
-// forward declaration to access logger without including emsesp.h
+// forward declaration for logger without including emsesp.h
 namespace emsesp {
-    class EMSESP {
-      public:
-        static uuid::log::Logger logger();
-    };
+    uuid::log::Logger logger();
 }
 
 template <class T>
@@ -28,7 +25,7 @@ class FSPersistence {
 
     void readFromFS() {
         if (_fs == nullptr || !_fs->exists("/")) {
-            emsesp::EMSESP::logger().err("File system not available, using defaults for %s", _filePath);
+            emsesp::logger().err("File system not available, using defaults for %s", _filePath);
             applyDefaults();
             return;
         }
@@ -62,7 +59,7 @@ class FSPersistence {
 #endif
         applyDefaults();
         if (!writeToFS()) {
-            emsesp::EMSESP::logger().err("Failed to create %s - file system not available", _filePath);
+            emsesp::logger().err("Failed to create %s - file system not available", _filePath);
         }
     }
 
@@ -117,7 +114,7 @@ class FSPersistence {
         if (!_updateHandlerId) {
             _updateHandlerId = _statefulService->addUpdateHandler([this] {
                 if (!writeToFS()) {
-                    emsesp::EMSESP::logger().err("Failed to persist %s - disabling handler", _filePath);
+                    emsesp::logger().err("Failed to persist %s - disabling handler", _filePath);
                     disableUpdateHandler();
                 }
             });

--- a/src/core/emsesp.h
+++ b/src/core/emsesp.h
@@ -296,7 +296,6 @@ class EMSESP {
   protected:
     static uuid::log::Logger logger_;
 };
-
 } // namespace emsesp
 
 #endif

--- a/src/core/emslogger.cpp
+++ b/src/core/emslogger.cpp
@@ -1,0 +1,9 @@
+#include "emsesp.h"
+
+namespace emsesp {
+
+uuid::log::Logger logger() {
+    return EMSESP::logger();
+}
+
+} // namespace emsesp


### PR DESCRIPTION
## Summary
- remove partial EMSESP definition from FSPersistence to prevent class redefinition
- add global `emsesp::logger()` wrapper and use it for persistence logging

## Testing
- `pio run -e s_4M`

------
https://chatgpt.com/codex/tasks/task_e_68ada1aa53c88323af95e8bd6bad653d